### PR TITLE
Fix: WebIDL link for converting an ECMAScript value to a dictionary

### DIFF
--- a/index.html
+++ b/index.html
@@ -5363,7 +5363,7 @@
           </p>
           <p>
             The algorithm for <dfn data-cite=
-            "WEBIDL#dfn-convert-idl-to-ecmascript-value" data-lt=
+            "WEBIDL#dfn-convert-ecmascript-to-idl-value" data-lt=
             "converting">converting an ECMAScript value to a dictionary</dfn>
             is defined by [[WEBIDL]].
           </p>


### PR DESCRIPTION
- Fixed the link to the WebIDL spec for converting an ECMAScript value to a dictionary